### PR TITLE
Element name and tag name in example should match.

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -258,7 +258,7 @@ class CustomCheckbox extends HTMLElement {
 
   // When the custom "checked" attribute changes,
   // keep the accessible checked state in sync.
-  attributeChangedCallback(name, old, newValue) {
+  attributeChangedCallback(name, oldValue, newValue) {
     switch(name) {
     case "checked":
       this.accessibleNode.checked = (newValue !== null);
@@ -272,7 +272,7 @@ class CustomCheckbox extends HTMLElement {
   }
 }
 
-customElements.define("x-checkbox", CustomCheckbox);
+customElements.define("custom-checkbox", CustomCheckbox);
 ```
 
 ```html


### PR DESCRIPTION
The defined element name and the tag name used below didn't match, so I fixed that. In addition, I renamed the second parameter of `attributeChangedCallback`, just for consistency.

Furthermore, I think the example can be improved by deleting the `switch` statement in the same function. A `switch` statement with only one `case` clause looks odd, especially since there is no need do check the name parameter at all, because only one attribute is observed.

It's not the purpose of this example to explain the Custom Element API, so to avoid distraction, I think it would be best to remove the statement and inline the comment above the function.

    attributeChangedCallback(name, oldValue, newValue) {

      // When the custom "checked" attribute changes,
      // keep the accessible checked state in sync.
      this.accessibleNode.checked = (newValue !== null);
    }

If you're ok with this, I can make another Commit/PR. If you want to keep the name check, I'd recommend to at least use an ordinary conditional statement instead of `switch`.